### PR TITLE
Fixed packaging to include plugins package.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,8 @@ setup(
     install_requires=['pandocfilters >= 1.4.2, < 2.0',
                       'pandoc-xnos >= 2.1.2, < 3.0'],
 
-    packages=['pandoclatexextensions'],
+    package_dir = {'pandoclatexextensions': 'pandoclatexextensions',
+                   'plugins': 'pandoclatexextensions/plugins'},
 
     entry_points={'console_scripts':
                   ['pandoc-latex-extensions = pandoclatexextensions:main']},


### PR DESCRIPTION
I don't really know how Python packaging works so please review what I have done. When building on my system (x86 Linux) the plugins package was not being created properly. I've made an edit to the `setup.py` that fixes the issue for me.

If this is merged then I can also upload and maintain my working PKGBUILD for the Arch linux user repository.

Thanks for the useful filters!